### PR TITLE
Feature/project enhancement

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,7 +30,7 @@ jobs:
           override: true
       - uses: actions-rs/cargo@v1
         with:
-          command: test --feautres "strict"
+          command: test --features "strict"
 
   fmt:
     name: Rustfmt

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Run cargo check
         uses: actions-rs/cargo@v1
         with:
-          command: check
+          command: check --features "strict"
 
   test:
     name: Test Suite
@@ -30,7 +30,7 @@ jobs:
           override: true
       - uses: actions-rs/cargo@v1
         with:
-          command: test
+          command: test --feautres "strict"
 
   fmt:
     name: Rustfmt

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,3 +49,19 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
+  
+  clippy_check:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install latest nightly
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+      - run: rustup component add clippy
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --features "strict"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,8 @@ jobs:
       - name: Run cargo check
         uses: actions-rs/cargo@v1
         with:
-          command: check --features "strict"
+          command: check
+          args: --features "strict"
 
   test:
     name: Test Suite
@@ -30,7 +31,8 @@ jobs:
           override: true
       - uses: actions-rs/cargo@v1
         with:
-          command: test --features "strict"
+          command: test
+          args: --features "strict"
 
   fmt:
     name: Rustfmt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,7 @@ serde = { version = "1.0.104", features = ["derive"] }
 r2d2 = "0.8.8"
 r2d2-diesel = "1.0.0"
 bcrypt = "0.6.1"
+
+[features]
+# Treat warnings as a build error.
+strict = []

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,7 @@
+merge_imports = true
+tab_spaces = 4
+max_width = 80
+color = "Never"
+use_small_heuristics = "Max"
+format_code_in_doc_comments = true
+wrap_comments = true

--- a/src/bin/create_user.rs
+++ b/src/bin/create_user.rs
@@ -1,9 +1,9 @@
 extern crate diesel;
 
 use dotenv::dotenv;
-use test_rocket_app::models::NewUser;
-use test_rocket_app::repositories::users;
-use test_rocket_app::{init_pool, DbConn};
+use test_rocket_app::{
+    init_pool, models::NewUser, repositories::users, DbConn,
+};
 
 fn main() {
     dotenv().ok();
@@ -16,7 +16,8 @@ fn main() {
         password_hash: "blabblablabcrypt nog nodig".into(),
     };
 
-    let created_user = users::insert(new_user, &conn).expect("Failed to create user");
+    let created_user =
+        users::insert(new_user, &conn).expect("Failed to create user");
 
     println!("{}", created_user.full_name);
     println!("----------\n");

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -4,8 +4,7 @@
 extern crate rocket;
 
 use dotenv::dotenv;
-use test_rocket_app::controllers::users;
-use test_rocket_app::init_pool;
+use test_rocket_app::{controllers::users, init_pool};
 
 #[catch(404)]
 fn not_found() -> String {

--- a/src/bin/show_users.rs
+++ b/src/bin/show_users.rs
@@ -1,6 +1,5 @@
 use dotenv::dotenv;
-use test_rocket_app::repositories::users;
-use test_rocket_app::{init_pool, DbConn};
+use test_rocket_app::{init_pool, repositories::users, DbConn};
 
 fn main() {
     dotenv().ok();

--- a/src/controllers/mod.rs
+++ b/src/controllers/mod.rs
@@ -1,6 +1,5 @@
 use diesel::result::Error;
-use rocket::handler::Outcome;
-use rocket::http::Status;
+use rocket::{handler::Outcome, http::Status};
 use rocket_contrib::json::Json;
 
 ///controller definitions

--- a/src/controllers/users.rs
+++ b/src/controllers/users.rs
@@ -1,10 +1,11 @@
 use rocket::{get, post};
-use rocket_contrib::json::Json;
-use rocket_contrib::uuid::Uuid;
+use rocket_contrib::{json::Json, uuid::Uuid};
 
-use crate::models::{NewUser, User};
-use crate::repositories::users;
-use crate::DbConn;
+use crate::{
+    models::{NewUser, User},
+    repositories::users,
+    DbConn,
+};
 
 use super::{IntoJsonResponse, JsonResponse};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,18 @@
 #![feature(decl_macro)]
+#![forbid(unsafe_code)]
+#![cfg_attr(feature = "strict", deny(warnings))]
+
 #[macro_use]
 extern crate diesel;
 extern crate dotenv;
 
-use std::env;
-use std::ops::Deref;
+use std::{env, ops::Deref};
 
 use diesel::pg::PgConnection;
 use r2d2_diesel::ConnectionManager;
-use rocket::http::Status;
-use rocket::request::FromRequest;
-use rocket::{request, Outcome, Request, State};
+use rocket::{
+    http::Status, request, request::FromRequest, Outcome, Request, State,
+};
 
 pub mod controllers;
 pub mod models;
@@ -33,7 +35,9 @@ pub struct DbConn(pub r2d2::PooledConnection<ConnectionManager<PgConnection>>);
 impl<'a, 'r> FromRequest<'a, 'r> for DbConn {
     type Error = ();
 
-    fn from_request(request: &'a Request<'r>) -> request::Outcome<DbConn, Self::Error> {
+    fn from_request(
+        request: &'a Request<'r>,
+    ) -> request::Outcome<DbConn, Self::Error> {
         let pool = request.guard::<State<Pool>>()?;
         match pool.get() {
             Ok(conn) => Outcome::Success(DbConn(conn)),

--- a/src/models.rs
+++ b/src/models.rs
@@ -23,18 +23,11 @@ pub struct NewUser {
 impl NewUser {
     pub fn hash_password(self) -> Self {
         // This is a destructure of `self`.
-        let Self {
-            full_name,
-            email,
-            password_hash,
-        } = self;
-        let password_hash = bcrypt::hash(password_hash, bcrypt::DEFAULT_COST).unwrap();
+        let Self { full_name, email, password_hash } = self;
+        let password_hash =
+            bcrypt::hash(password_hash, bcrypt::DEFAULT_COST).unwrap();
 
-        Self {
-            full_name,
-            email,
-            password_hash,
-        }
+        Self { full_name, email, password_hash }
     }
 }
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::single_component_path_imports)]
+
 use diesel::sql_types::Timestamp;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;

--- a/src/repositories/users.rs
+++ b/src/repositories/users.rs
@@ -1,9 +1,10 @@
-use diesel;
-use diesel::prelude::*;
+use diesel::{self, prelude::*};
 use uuid::Uuid;
 
-use crate::models::{NewUser, User};
-use crate::schema::users;
+use crate::{
+    models::{NewUser, User},
+    schema::users,
+};
 
 pub fn all(connection: &PgConnection) -> QueryResult<Vec<User>> {
     users::table.load::<User>(&*connection)
@@ -14,15 +15,15 @@ pub fn get(id: Uuid, connection: &PgConnection) -> QueryResult<User> {
 }
 
 pub fn insert(user: NewUser, connection: &PgConnection) -> QueryResult<User> {
-    diesel::insert_into(users::table)
-        .values(&user)
-        .get_result(connection)
+    diesel::insert_into(users::table).values(&user).get_result(connection)
 }
 
-pub fn update(id: Uuid, user: User, connection: &PgConnection) -> QueryResult<User> {
-    diesel::update(users::table.find(id))
-        .set(&user)
-        .get_result(connection)
+pub fn update(
+    id: Uuid,
+    user: User,
+    connection: &PgConnection,
+) -> QueryResult<User> {
+    diesel::update(users::table.find(id)).set(&user).get_result(connection)
 }
 
 pub fn delete(id: Uuid, connection: &PgConnection) -> QueryResult<usize> {

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::single_component_path_imports)]
+
 table! {
     items (id) {
         id -> Uuid,


### PR DESCRIPTION
Firstly, disallow the use of `unsafe` trough the top level crate attribute `#![forbit(unsafe_code)]`.
Secondly, adds a feature that makes warning hard errors. This feature is enabled in the github action builds as well, so you might be able to compile locally with warnings, but get a fail on github actions. In order to locally compile with this feature, use `cargo build --features "strict"`.

Lastly, this PR adds a `rustfmt.toml`, which defines a standard format style, and this format style is already used in this PR.