### PR TITLE
minor changes. Also moves the database stuff to its own module

### DIFF
--- a/src/bin/create_user.rs
+++ b/src/bin/create_user.rs
@@ -1,14 +1,12 @@
 extern crate diesel;
 
 use dotenv::dotenv;
-use test_rocket_app::{
-    init_pool, models::NewUser, repositories::users, DbConn,
-};
+use test_rocket_app::{database, models::NewUser, repositories::users};
 
 fn main() {
     dotenv().ok();
-    let pool = init_pool();
-    let conn = DbConn(pool.get().unwrap());
+    let pool = database::init_pool();
+    let conn = database::DbConn(pool.get().unwrap());
 
     let new_user = NewUser {
         full_name: "Kasper van den berg".into(),

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -4,7 +4,7 @@
 extern crate rocket;
 
 use dotenv::dotenv;
-use test_rocket_app::{controllers::users, init_pool};
+use test_rocket_app::{controllers::users, database};
 
 #[catch(404)]
 fn not_found() -> String {
@@ -14,7 +14,7 @@ fn not_found() -> String {
 fn main() {
     dotenv().ok();
     rocket::ignite()
-        .manage(init_pool())
+        .manage(database::init_pool())
         .mount("/api", routes![users::index, users::get, users::store])
         .register(catchers![not_found])
         .launch();

--- a/src/bin/show_users.rs
+++ b/src/bin/show_users.rs
@@ -1,10 +1,10 @@
 use dotenv::dotenv;
-use test_rocket_app::{init_pool, repositories::users, DbConn};
+use test_rocket_app::{database, repositories::users};
 
 fn main() {
     dotenv().ok();
-    let pool = init_pool();
-    let conn = DbConn(pool.get().unwrap());
+    let pool = database::init_pool();
+    let conn = database::DbConn(pool.get().unwrap());
 
     let results = users::all(&conn).expect("Failed to get users");
     println!("Displaying {} users:", results.len());

--- a/src/controllers/mod.rs
+++ b/src/controllers/mod.rs
@@ -6,15 +6,15 @@ use rocket_contrib::json::Json;
 pub mod users;
 
 /// Internal types used by controllers
-type JsonResponse<U> = Result<Json<U>, Outcome<'static>>;
+type JsonResponse<'r, U> = Result<Json<U>, Outcome<'r>>;
 
-trait IntoJsonResponse<U> {
-    fn from_query_result(result: Result<U, Error>) -> JsonResponse<U>;
+trait FromResult<T, E> {
+    fn from_result(r: Result<T, E>) -> Self;
 }
 
-impl<U> IntoJsonResponse<U> for JsonResponse<U> {
-    fn from_query_result(result: Result<U, Error>) -> JsonResponse<U> {
-        result.map(Json).map_err(error_status)
+impl<'r, T> FromResult<T, Error> for JsonResponse<'r, T> {
+    fn from_result(r: Result<T, Error>) -> Self {
+        r.map(Json).map_err(error_status)
     }
 }
 

--- a/src/controllers/users.rs
+++ b/src/controllers/users.rs
@@ -7,20 +7,20 @@ use crate::{
     DbConn,
 };
 
-use super::{IntoJsonResponse, JsonResponse};
+use super::{FromResult, JsonResponse};
 
 #[get("/user")]
-pub fn index(connection: DbConn) -> JsonResponse<Vec<User>> {
-    JsonResponse::from_query_result(users::all(&connection))
+pub fn index<'a>(connection: DbConn) -> JsonResponse<'a, Vec<User>> {
+    JsonResponse::from_result(users::all(&connection))
 }
 
 #[get("/user/<_id>")]
-pub fn get(connection: DbConn, _id: Uuid) -> JsonResponse<User> {
-    JsonResponse::from_query_result(users::get(_id.into_inner(), &connection))
+pub fn get<'a>(connection: DbConn, _id: Uuid) -> JsonResponse<'a, User> {
+    JsonResponse::from_result(users::get(_id.into_inner(), &connection))
 }
 
 #[post("/user", format = "application/json", data = "<user>")]
-pub fn store(user: Json<NewUser>, conn: DbConn) -> JsonResponse<User> {
+pub fn store<'a>(user: Json<NewUser>, conn: DbConn) -> JsonResponse<'a, User> {
     let new_user = user.into_inner().hash_password();
-    JsonResponse::from_query_result(users::insert(new_user, &conn))
+    JsonResponse::from_result(users::insert(new_user, &conn))
 }

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,0 +1,42 @@
+use std::{env, ops::Deref};
+
+use diesel::pg::PgConnection;
+use r2d2_diesel::ConnectionManager;
+use rocket::{
+    http::Status, request, request::FromRequest, Outcome, Request, State,
+};
+
+type Pool = r2d2::Pool<ConnectionManager<PgConnection>>;
+
+pub fn init_pool() -> Pool {
+    let manager = ConnectionManager::<PgConnection>::new(database_url());
+    Pool::new(manager).expect("db pool")
+}
+
+fn database_url() -> String {
+    env::var("DATABASE_URL").expect("DATABASE_URL must be set")
+}
+
+pub struct DbConn(pub r2d2::PooledConnection<ConnectionManager<PgConnection>>);
+
+impl<'a, 'r> FromRequest<'a, 'r> for DbConn {
+    type Error = ();
+
+    fn from_request(
+        request: &'a Request<'r>,
+    ) -> request::Outcome<DbConn, Self::Error> {
+        let pool = request.guard::<State<Pool>>()?;
+        match pool.get() {
+            Ok(conn) => Outcome::Success(DbConn(conn)),
+            Err(_) => Outcome::Failure((Status::ServiceUnavailable, ())),
+        }
+    }
+}
+
+impl Deref for DbConn {
+    type Target = PgConnection;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,50 +6,9 @@
 extern crate diesel;
 extern crate dotenv;
 
-use std::{env, ops::Deref};
-
-use diesel::pg::PgConnection;
-use r2d2_diesel::ConnectionManager;
-use rocket::{
-    http::Status, request, request::FromRequest, Outcome, Request, State,
-};
-
 pub mod controllers;
+pub mod database;
 pub mod models;
 pub mod repositories;
 pub mod schema;
-
-type Pool = r2d2::Pool<ConnectionManager<PgConnection>>;
-
-pub fn init_pool() -> Pool {
-    let manager = ConnectionManager::<PgConnection>::new(database_url());
-    Pool::new(manager).expect("db pool")
-}
-
-fn database_url() -> String {
-    env::var("DATABASE_URL").expect("DATABASE_URL must be set")
-}
-
-pub struct DbConn(pub r2d2::PooledConnection<ConnectionManager<PgConnection>>);
-
-impl<'a, 'r> FromRequest<'a, 'r> for DbConn {
-    type Error = ();
-
-    fn from_request(
-        request: &'a Request<'r>,
-    ) -> request::Outcome<DbConn, Self::Error> {
-        let pool = request.guard::<State<Pool>>()?;
-        match pool.get() {
-            Ok(conn) => Outcome::Success(DbConn(conn)),
-            Err(_) => Outcome::Failure((Status::ServiceUnavailable, ())),
-        }
-    }
-}
-
-impl Deref for DbConn {
-    type Target = PgConnection;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub(crate) use database::*;

--- a/src/models.rs
+++ b/src/models.rs
@@ -24,12 +24,10 @@ pub struct NewUser {
 
 impl NewUser {
     pub fn hash_password(self) -> Self {
-        // This is a destructure of `self`.
-        let Self { full_name, email, password_hash } = self;
         let password_hash =
-            bcrypt::hash(password_hash, bcrypt::DEFAULT_COST).unwrap();
+            bcrypt::hash(&self.password_hash, bcrypt::DEFAULT_COST).unwrap();
 
-        Self { full_name, email, password_hash }
+        Self { password_hash, ..self }
     }
 }
 


### PR DESCRIPTION
Moves the database related code into its own module. This module can be accessed by the outside world, trough `database::{/*whatever*/}`. Note the `pub (crate) use database::*`, which makes everything in the database module accessable _in this crate only_ without having to import it from `database` in places.

Also changes how `IntoJsonResponse` is named. Its now named `FromResult` with a dedicated method `from_result`. The previous naming `IntoJsonResponse` with a method called `from_query_result` doesnt follow the From and Into convention. From should only contain `from` methods, while Into should only contain `into` methods