### PR TITLE
Fix clippy issue after diesel migrate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,5 +10,8 @@ pub mod controllers;
 pub mod database;
 pub mod models;
 pub mod repositories;
+
+#[allow(clippy::single_component_path_imports)]
 pub mod schema;
+
 pub(crate) use database::*;

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::single_component_path_imports)]
-
 table! {
     items (id) {
         id -> Uuid,


### PR DESCRIPTION
Moves the clippy lint to the module decl in lib.rs, allowing diesel migrate to overwrite schema.rs without losing the lint